### PR TITLE
Fix loading spinner state

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -5,7 +5,7 @@ import {useEffect, useState} from "react";
 import Head from "next/head";
 
 export default function App() {
-    const [isLoading, setIsLoading] = useState(false); // State to track if the site is loading
+    const [isLoading, setIsLoading] = useState(true); // State to track if the site is loading
 
 
     useEffect(() => {


### PR DESCRIPTION
## Summary
- initialize loading spinner state to `true` so spinner shows until the page fully loads

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684e6f08ad248323969ec2231c182bd3